### PR TITLE
More descriptive error messages when file upload/download fails

### DIFF
--- a/app/controllers/integrations_controller.rb
+++ b/app/controllers/integrations_controller.rb
@@ -50,18 +50,36 @@ class IntegrationsController < ApplicationController
 
     metadata[:source] = get_integration_name_from_params()
 
+    if !metadata[:error_message].nil?
+      response = {:error => {:message => metadata[:error_message]}}
+      render :json => response, :status => :bad_request and return
+    end
+
     render :json => {:metadata => metadata}
   end
 
   def download_item
     metadata = params[:metadata]
-    body, file_name = @integration.download_item(metadata)
+    body, file_name, error_message = @integration.download_item(metadata)
+
+    if !error_message.nil?
+      response = {:error => {:message => error_message}}
+      render :json => response, :status => :bad_request and return
+    end
+
     send_data body, filename: file_name
   end
 
   def delete_item
     metadata = params[:metadata]
-    @integration.delete_item(metadata)
+    error_message = @integration.delete_item(metadata)
+
+    if !error_message.nil?
+      response = {:error => {:message => error_message}}
+      render :json => response, :status => :bad_request and return
+    end
+
+    head :no_content
   end
 
   def oauth_redirect

--- a/app/lib/integrations/webdav_integration.rb
+++ b/app/lib/integrations/webdav_integration.rb
@@ -22,23 +22,39 @@ class WebdavIntegration
     end
 
     file_path = URI::encode(file_path)
-    self.dav.put_string(file_path, JSON.pretty_generate(payload.as_json))
 
-    return {:file_path => file_path}
+    begin
+      self.dav.put_string(file_path, JSON.pretty_generate(payload.as_json))
+    rescue Exception => e
+      @error_msg = e.message
+    end
+
+    return {:file_path => file_path, :error_message => @error_msg}
   end
 
   def download_item(metadata = {})
     body = nil, filename = nil
-    self.dav.find(metadata[:file_path]) do |item|
-      body = item.content
-      filename = metadata[:file_path]
+
+    begin
+      self.dav.find(metadata[:file_path]) do |item|
+        body = item.content
+        filename = metadata[:file_path]
+      end
+    rescue Exception => e
+      @error_msg = e.message
     end
 
-    return body, filename
+    return body, filename, @error_msg
   end
 
   def delete_item(metadata)
-    self.dav.delete(metadata[:file_path])
+    begin
+      self.dav.delete(metadata[:file_path])
+    rescue Exception => e
+      @error_msg = e.message
+    end
+
+    return @error_msg
   end
 
   def dav


### PR DESCRIPTION
Original issue: #4 

- A descriptive error message is added to the JSON response. 
- The `400 Bad Request` status code is set if the request fails.

This applies to the `save_item`, `download_item` and **`delete_item`** endpoints.

For the **`delete_item`** endpoint, the `204 No Content` status code is set if the request is successful. Else, the `400 Bad Request` status code is set and the error message is added to the JSON response.

[filesafe-client](https://github.com/standardnotes/filesafe-client) should be updated to use these features (I can take care of this, just let me know).

