### PR TITLE
fix: change wording to be consistent with google settings

### DIFF
--- a/app/lib/integrations/google_drive_integration.rb
+++ b/app/lib/integrations/google_drive_integration.rb
@@ -36,7 +36,7 @@ class GoogleDriveIntegration
       auth_client.fetch_access_token!
       secret_hash = auth_client.as_json.slice("expiry", "refresh_token", "access_token")
       if secret_hash["refresh_token"] == nil
-        return {:error => {:message => 'You have already authorized this application. In order to re-configure, go to <a href="https://myaccount.google.com/permissions">https://myaccount.google.com/permissions</a> and revoke access to "Standard Notes".'}}
+        return {:error => {:message => 'You have already authorized this application. In order to re-configure, go to <a href="https://myaccount.google.com/permissions">https://myaccount.google.com/permissions</a> and remove access to "Standard Notes".'}}
       else
         secret_hash[:expires_at] = auth_client.expires_at
         secret_base64 = Base64.encode64(secret_hash.to_json)


### PR DESCRIPTION
- While testing out the bold editor I encountered the failure page many times. 
- This is just a minor change to be consistent with Google's choice of words (less confusion for users). 
- The only concern I might have is that 'revoke' may be the more precise terminology based on the definition.