### PR TITLE
Add support for S3 compatible endpoints

### DIFF
--- a/app/lib/integrations/aws_s3_integration.rb
+++ b/app/lib/integrations/aws_s3_integration.rb
@@ -36,6 +36,7 @@ class AwsS3Integration
   def bucket
     @bucket ||= begin
       s3 = Aws::S3::Resource.new({
+        endpoint: @auth_params["endpoint"],
         region: @auth_params["region"],
         credentials: Aws::Credentials.new(@auth_params["key"], @auth_params["secret"])
       })

--- a/app/views/integrations/form_aws_s3.html.haml
+++ b/app/views/integrations/form_aws_s3.html.haml
@@ -2,6 +2,7 @@
   .sk-panel-form
     = form_tag({controller: "integrations", :action => "submit_form"}, :method => "post") do
       = fields_for :auth_data do |ad|
+        = ad.text_field :endpoint, :placeholder => "S3 Compatible Endpoint (optional)", :class => "sk-input contrast"
         = ad.text_field :region, :placeholder => "Region, e.g., eu-central-1", :required => true, :class => "sk-input contrast"
         = ad.text_field :bucket, :placeholder => "S3 Bucket", :required => true, :class => "sk-input contrast"
         = ad.text_field :key, :placeholder => "Access Key ID", :required => true, :class => "sk-input contrast"


### PR DESCRIPTION
I just tested this against Scaleway Object Storage and its working nice.

Example config:
> endpoint: `https://s3.fr-par.scw.cloud`
> region: `fr-par`
> bucket: `bucketname`
> access-key-id: `api-key-access-key-id`
> secret-key: `api-secret-key`


This should close #10 too

The only thing left to test is leaving an empty "endpoint" field, which I think it should behave exactly as before but I do not have an AWS Bucket to test

---

I am not sure about this PR. I had it ready to publish but just before submitting it, I thought that this may cause some problems, since leaving the endpoint an user-defined field means the server will open connections to any host...
If that is not acceptable, how about we could hardcode a list of providers and let the user select from that list instead?